### PR TITLE
add option to hide plugin banner

### DIFF
--- a/src/com/geitenijs/keepchunks/Main.java
+++ b/src/com/geitenijs/keepchunks/Main.java
@@ -10,9 +10,9 @@ public class Main extends JavaPlugin {
     public void onEnable() {
         Main.plugin = this;
         if (version.contains("v1_17_R1") || version.contains("v1_16_R3") || version.contains("v1_16_R2") || version.contains("v1_16_R1") || version.contains("v1_15_R1") || version.contains("v1_14_R1") || version.contains("v1_13_R2")) {
-            Utilities.pluginBanner();
             Hooks.registerHooks();
             Utilities.createConfigs();
+            Utilities.pluginBanner();
             Utilities.registerCommandsAndCompletions();
             Utilities.registerEvents();
             Utilities.loadChunks();

--- a/src/com/geitenijs/keepchunks/Utilities.java
+++ b/src/com/geitenijs/keepchunks/Utilities.java
@@ -37,26 +37,34 @@ public class Utilities {
     }
 
     static void pluginBanner() {
-        consoleBanner("");
-        consoleBanner("&2 _     _                  &8 _______ _                 _          ");
-        consoleBanner("&2(_)   | |                 &8(_______) |               | |  &2v" + Strings.VERSION);
-        consoleBanner("&2 _____| |_____ _____ ____ &8 _      | |__  _   _ ____ | |  _  ___ ");
-        consoleBanner("&2|  _   _) ___ | ___ |  _ \\&8| |     |  _ \\| | | |  _ \\| |_/ )/___)");
-        consoleBanner("&2| |  \\ \\| ____| ____| |_| &8| |_____| | | | |_| | | | |  _ (|___ |");
-        consoleBanner("&2|_|   \\_)_____)_____)  __/&8 \\______)_| |_|____/|_| |_|_| \\_|___/ ");
-        consoleBanner("&2                    |_|   &8                                      ");
-        consoleBanner("");
+    	if (config.getBoolean("general.allowpluginbanner")) {
+    		
+	        consoleBanner("");
+	        consoleBanner("&2 _     _                  &8 _______ _                 _          ");
+	        consoleBanner("&2(_)   | |                 &8(_______) |               | |  &2v" + Strings.VERSION);
+	        consoleBanner("&2 _____| |_____ _____ ____ &8 _      | |__  _   _ ____ | |  _  ___ ");
+	        consoleBanner("&2|  _   _) ___ | ___ |  _ \\&8| |     |  _ \\| | | |  _ \\| |_/ )/___)");
+	        consoleBanner("&2| |  \\ \\| ____| ____| |_| &8| |_____| | | | |_| | | | |  _ (|___ |");
+	        consoleBanner("&2|_|   \\_)_____)_____)  __/&8 \\______)_| |_|____/|_| |_|_| \\_|___/ ");
+	        consoleBanner("&2                    |_|   &8                                      ");
+	        consoleBanner("");
+	        
+    	}
     }
 
     static void errorBanner() {
-        consoleBanner("");
-        consoleBanner("&c _______ ______  ______ _______ ______  ");
-        consoleBanner("&c(_______|_____ \\(_____ (_______|_____ \\ ");
-        consoleBanner("&c _____   _____) )_____) )     _ _____) )");
-        consoleBanner("&c|  ___) |  __  /|  __  / |   | |  __  / ");
-        consoleBanner("&c| |_____| |  \\ \\| |  \\ \\ |___| | |  \\ \\ ");
-        consoleBanner("&c|_______)_|   |_|_|   |_\\_____/|_|   |_|");
-        consoleBanner("");
+    	if (config.getBoolean("general.allowpluginbanner")) {
+    		
+	        consoleBanner("");
+	        consoleBanner("&c _______ ______  ______ _______ ______  ");
+	        consoleBanner("&c(_______|_____ \\(_____ (_______|_____ \\ ");
+	        consoleBanner("&c _____   _____) )_____) )     _ _____) )");
+	        consoleBanner("&c|  ___) |  __  /|  __  / |   | |  __  / ");
+	        consoleBanner("&c| |_____| |  \\ \\| |  \\ \\ |___| | |  \\ \\ ");
+	        consoleBanner("&c|_______)_|   |_|_|   |_\\_____/|_|   |_|");
+	        consoleBanner("");
+	        
+    	}
     }
 
     static void createConfigs() {
@@ -73,6 +81,7 @@ public class Utilities {
         config.addDefault("general.colourfulconsole", true);
         config.addDefault("general.debug", false);
         config.addDefault("general.releaseallprotection", true);
+        config.addDefault("general.allowpluginbanner", true);
         config.addDefault("updates.check", true);
         config.addDefault("updates.notify", true);
         config.set("chunkload.dynamic", null);


### PR DESCRIPTION
I've added an option to deactivate the plugin banner with `general.allowpluginbanner = false` (`true` by default).

The reason is the unuseful big startup message.


allowpluginbanner = true (default)

```
[14:10:23] [Server thread/INFO]: [KeepChunks] Enabling KeepChunks v1.6.8
[14:10:23] [Server thread/INFO]: 
[14:10:23] [Server thread/INFO]:  _     _                   _______ _                 _          
[14:10:23] [Server thread/INFO]: (_)   | |                 (_______) |               | |  v1.6.8
[14:10:23] [Server thread/INFO]:  _____| |_____ _____ ____  _      | |__  _   _ ____ | |  _  ___ 
[14:10:23] [Server thread/INFO]: |  _   _) ___ | ___ |  _ \| |     |  _ \| | | |  _ \| |_/ )/___)
[14:10:23] [Server thread/INFO]: | |  \ \| ____| ____| |_| | |_____| | | | |_| | | | |  _ (|___ |
[14:10:23] [Server thread/INFO]: |_|   \_)_____)_____)  __/ \______)_| |_|____/|_| |_|_| \_|___/ 
[14:10:23] [Server thread/INFO]:                     |_|                                         
[14:10:23] [Server thread/INFO]: 
[14:10:23] [Server thread/INFO]: [KeepChunks] KeepChunks v1.6.8 has been enabled
```


allowpluginbanner = false

```
[14:10:23] [Server thread/INFO]: [KeepChunks] Enabling KeepChunks v1.6.8
[14:10:23] [Server thread/INFO]: [KeepChunks] KeepChunks v1.6.8 has been enabled
```